### PR TITLE
fix: use a unique key to track components

### DIFF
--- a/src/Host.tsx
+++ b/src/Host.tsx
@@ -23,7 +23,6 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
     key: number;
     children?: React.ReactNode;
   }[] = [];
-  let nextKey = 0;
 
   React.useEffect(() => {
     while (queue.length && managerRef.current) {
@@ -46,7 +45,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
   }, []);
 
   const mount = (children: React.ReactNode): number => {
-    const key = nextKey++;
+    const key = Date.now();
 
     if (managerRef.current) {
       managerRef.current.mount(key, children);


### PR DESCRIPTION
This seems to fix the issue, the `nextKey++` would always seem to generate duplicate keys in some manor. Using `Date.now()` produces much more random and unique keys that stops the refs from being lost.

### Before

![Screenshot 2020-08-10 at 11 22 48](https://user-images.githubusercontent.com/713128/89773469-dc8b8900-dafb-11ea-8d52-b5354edba963.png)

### After

![Screenshot 2020-08-10 at 12 26 00](https://user-images.githubusercontent.com/713128/89778621-bff44e80-db05-11ea-96b6-0e17394a3ce7.png)


Fixes #7 
Fixes #5 