### PR TITLE
Add random number to key to avoid clashes on rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn.lock
 .vscode/
 lib/
 .watchmanconfig
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   "peerDependencies": {
     "react": "> 15.0.0",
     "react-native": "> 0.50.0"
+  },
+  "dependencies": {
+    "uuid": "^8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "react-native": "> 0.50.0"
   },
   "dependencies": {
-    "uuid": "^8.3.0"
+    "uuid": "8.3.0"
   }
 }

--- a/src/Consumer.tsx
+++ b/src/Consumer.tsx
@@ -8,7 +8,7 @@ interface IConsumerProps {
 }
 
 export const Consumer = ({ children, manager }: IConsumerProps): null => {
-  const key = React.useRef<number | undefined>(undefined);
+  const key = React.useRef<string | undefined>(undefined);
 
   const checkManager = (): void => {
     if (!manager) {

--- a/src/Host.tsx
+++ b/src/Host.tsx
@@ -45,7 +45,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
   }, []);
 
   const mount = (children: React.ReactNode): number => {
-    const key = Date.now();
+    const key = `portal_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
 
     if (managerRef.current) {
       managerRef.current.mount(key, children);

--- a/src/Host.tsx
+++ b/src/Host.tsx
@@ -46,7 +46,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
   }, []);
 
   const mount = (children: React.ReactNode): string => {
-    const key = uuidv4();
+    const key = `portalize_${uuidv4()}`;
 
     if (managerRef.current) {
       managerRef.current.mount(key, children);

--- a/src/Host.tsx
+++ b/src/Host.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { View, ViewStyle } from 'react-native';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Manager, IManagerHandles } from './Manager';
 
@@ -9,9 +10,9 @@ interface IHostProps {
 }
 
 export interface IProvider {
-  mount(children: React.ReactNode): number;
-  update(key?: number, children?: React.ReactNode): void;
-  unmount(key?: number): void;
+  mount(children: React.ReactNode): string;
+  update(key?: string, children?: React.ReactNode): void;
+  unmount(key?: string): void;
 }
 
 export const Context = React.createContext<IProvider | null>(null);
@@ -20,7 +21,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
   const managerRef = React.useRef<IManagerHandles>(null);
   const queue: {
     type: 'mount' | 'update' | 'unmount';
-    key: number;
+    key: string;
     children?: React.ReactNode;
   }[] = [];
 
@@ -44,8 +45,8 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
     }
   }, []);
 
-  const mount = (children: React.ReactNode): number => {
-    const key = `portal_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+  const mount = (children: React.ReactNode): string => {
+    const key = uuidv4();
 
     if (managerRef.current) {
       managerRef.current.mount(key, children);
@@ -56,7 +57,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
     return key;
   };
 
-  const update = (key: number, children: React.ReactNode): void => {
+  const update = (key: string, children: React.ReactNode): void => {
     if (managerRef.current) {
       managerRef.current.update(key, children);
     } else {
@@ -73,7 +74,7 @@ export const Host = ({ children, style }: IHostProps): JSX.Element => {
     }
   };
 
-  const unmount = (key: number): void => {
+  const unmount = (key: string): void => {
     if (managerRef.current) {
       managerRef.current.unmount(key);
     } else {

--- a/src/Manager.tsx
+++ b/src/Manager.tsx
@@ -2,22 +2,22 @@ import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 
 export interface IManagerHandles {
-  mount(key: number, children: React.ReactNode): void;
-  update(key?: number, children?: React.ReactNode): void;
-  unmount(key?: number): void;
+  mount(key: string, children: React.ReactNode): void;
+  update(key?: string, children?: React.ReactNode): void;
+  unmount(key?: string): void;
 }
 
 export const Manager = React.forwardRef((_, ref): any => {
-  const [portals, setPortals] = React.useState<{ key: number; children: React.ReactNode }[]>([]);
+  const [portals, setPortals] = React.useState<{ key: string; children: React.ReactNode }[]>([]);
 
   React.useImperativeHandle(
     ref,
     (): IManagerHandles => ({
-      mount(key: number, children: React.ReactNode): void {
+      mount(key: string, children: React.ReactNode): void {
         setPortals(prev => [...prev, { key, children }]);
       },
 
-      update(key: number, children: React.ReactNode): void {
+      update(key: string, children: React.ReactNode): void {
         setPortals(prev =>
           prev.map(item => {
             if (item.key === key) {
@@ -29,7 +29,7 @@ export const Manager = React.forwardRef((_, ref): any => {
         );
       },
 
-      unmount(key: number): void {
+      unmount(key: string): void {
         setPortals(prev => prev.filter(item => item.key !== key));
       },
     }),


### PR DESCRIPTION
Avoids issues where multiple portals on one screen can have same key (Date.now() is not sufficient on its own if rendering is fast enough).

Could look at using something like uuid instead of a random number to guarantee more uniqueness? 👍 